### PR TITLE
Feature: Handle parents having the same email address properly.

### DIFF
--- a/addons/schoolmanager/class_importaccounts.inc
+++ b/addons/schoolmanager/class_importaccounts.inc
@@ -1087,6 +1087,7 @@ class importaccounts extends plugin{
                     /* let's try "fuzzy" search (only look for givenName and sn) */
                     $_ldapfilter = "(&(objectClass=gosaAccount)(sn=".$row['main_account']['sn'][0].")(givenName=".$row['main_account']['givenName'][0]."))";
                     $ldapsearch = $this->_ldap->search($_ldapfilter, array("uid", "sn","givenName","gender","dateOfBirth", "mail", "alias", "departmentNumber", "employeeNumber"));
+
                     $gosa_main_accounts = array();
                     while ($ldap_obj = $this->_ldap->fetch($ldapsearch)) {
                         $gosa_main_accounts[] = $ldap_obj;
@@ -1250,79 +1251,99 @@ class importaccounts extends plugin{
                 {
                     foreach ($row['aux_accounts'] as $idx_aux => $aux_account)
                     {
+                        /*
+                         * Don't perform on this aux-user dataset if:
+                         *   - parent1 and parent2 have the same email AND
+                         *   - aux-user is parent2
+                         */
+                        if (strpos($aux_account['_status'][0], 'same-mail-as-parent1') !== FALSE)
+                        {
+                            continue;
+                        }
+
+
+                        // $gosa_aux_accounts still holds old values..
+                        unset($gosa_aux_accounts);
 
                         if (isset($aux_account['mail'][0])) {
-
-
-                            $_ldapfilter = "(&(objectClass=gosaAccount)(mail=".$aux_account['mail'][0]."))";
+                            $_ldapfilter = "(&(objectClass=gosaAccount)(uid=".$aux_account['mail'][0]."))";
                             $ldapsearch = $this->_ldap->search($_ldapfilter, array("sn","givenName","mail"));
+
+
                             $gosa_aux_accounts = array();
                             while ($ldap_obj = $this->_ldap->fetch($ldapsearch)) {
                                 $gosa_aux_accounts[] = $ldap_obj;
                             }
-                            if ((is_countable ($gosa_aux_accounts)) and (count ($gosa_aux_accounts) == 1)) {
 
-                                $gosa_account = $gosa_aux_accounts[0];
+                        } else {
+                            // E-Mail is not set. Skip.
+                            continue;
+                        }
 
-                                if ($this->compareObjects($aux_account, $gosa_account, array("mail"), "", TRUE)===TRUE)
+
+                        if ((is_countable ($gosa_aux_accounts)) and (count ($gosa_aux_accounts) == 0))
+                        {
+
+                            // Nothing to do. Just create the account.
+                        } elseif ((is_countable ($gosa_aux_accounts)) and (count ($gosa_aux_accounts) == 1))
+                        {
+
+                            // We only found one account, assume it's at 0th place.
+                            $gosa_account = $gosa_aux_accounts[0];
+
+                            $expected_base= $this->genAccountBase($aux_account);
+                            $gosa_account_dn= $gosa_account['dn'];
+
+                            /* detect status */
+
+                            /*
+                                * FIXME: Support automatic moving of AUX accounts!!!
+                                */
+
+                            $this->csvinfo['data_preldap'][$key]['aux_accounts'][$idx_aux]['_status'][0]= 'exists';
+
+                            $_actions= array();
+
+                            /*
+                                * FIXME: Hard-code a "none" action here in case we found a matching account in LDAP.
+                                *        Later, we need to make actions more configurable...
+                                */
+
+                            /* only update attributes that are already set in the main account dataset */
+                            $_updatable_attrs= array();
+                            foreach(array("sn", "givenName") as $_attr)
+                            {
+                                if(isset($aux_account[$_attr]))
                                 {
-                                    $expected_base= $this->genAccountBase($aux_account);
-                                    $gosa_account_dn= $gosa_account['dn'];
-
-                                    /* detect status */
-
-                                    /*
-                                     * FIXME: Support automatic moving of AUX accounts!!!
-                                     */
-
-                                    $this->csvinfo['data_preldap'][$key]['aux_accounts'][$idx_aux]['_status'][0]= 'exists';
-
-                                    $_actions= array();
-
-                                    /*
-                                     * FIXME: Hard-code a "none" action here in case we found a matching account in LDAP.
-                                     *        Later, we need to make actions more configurable...
-                                     */
-
-                                    /* only update attributes that are already set in the main account dataset */
-                                    $_updatable_attrs= array();
-                                    foreach(array("sn", "givenName") as $_attr)
-                                    {
-                                        if(isset($aux_account[$_attr]))
-                                        {
-                                            $_updatable_attrs[]= $_attr;
-                                        }
-                                    }
-
-                                    $_check_attrs= $this->compareObjects($aux_account, $gosa_account, $_updatable_attrs, "update-");
-                                    if ($_check_attrs===TRUE)
-                                    {
-                                        /* nothing to do */
-                                    }
-                                    else {
-                                        $_actions= array_merge($_actions, $_check_attrs);
-                                    }
-
-                                    if(empty($_actions))
-                                    {
-                                        $_actions[]= 'none';
-                                    }
-
-                                    $this->csvinfo['data_preldap'][$key]['aux_accounts'][$idx_aux]['_actions'][0]= implode(",", $_actions);
-
-                                    $this->csvinfo['data_preldap'][$key]['aux_accounts'][$idx_aux]['_dn_ldap']= array($gosa_account_dn);
-
-                                    /* FIXME: We need a check that DN generation for aux accounts will actually work, probably when
-                                     *        constructing $this->csvinfo['data_preldap'].
-                                     */
-                                    $this->csvinfo['data_preldap'][$key]['aux_accounts'][$idx_aux]['_base']= array($expected_base);
+                                    $_updatable_attrs[]= $_attr;
                                 }
                             }
-                        }
-                        elseif ((is_countable ($gosa_aux_accounts)) and (count ($gosa_aux_accounts) > 1)) {
+
+                            $_check_attrs= $this->compareObjects($aux_account, $gosa_account, $_updatable_attrs, "update-");
+                            if ($_check_attrs===TRUE)
+                            {
+                                /* nothing to do */
+                            }
+                            else {
+                                $_actions= array_merge($_actions, $_check_attrs);
+                            }
+
+                            if(empty($_actions))
+                            {
+                                $_actions[]= 'none';
+                            }
+
+                            $this->csvinfo['data_preldap'][$key]['aux_accounts'][$idx_aux]['_actions'][0]= implode(",", $_actions);
+
+                            $this->csvinfo['data_preldap'][$key]['aux_accounts'][$idx_aux]['_dn_ldap']= array($gosa_account_dn);
+
+                            /* FIXME: We need a check that DN generation for aux accounts will actually work, probably when
+                                *        constructing $this->csvinfo['data_preldap'].
+                                */
+                            $this->csvinfo['data_preldap'][$key]['aux_accounts'][$idx_aux]['_base']= array($expected_base);
+                        } elseif ((is_countable ($gosa_aux_accounts)) and (count ($gosa_aux_accounts) > 1)) {
                             msg_dialog::display (_ ("LDAP Tree Error"),_ ("The LDAP search query with filter '".$_ldapfilter."' returned more than one account object. There should only be one such object in the LDAP tree."), ERROR_DIALOG);
-                        }
-                        elseif ((!is_countable ($gosa_aux_accounts))) {
+                        } elseif ((!is_countable ($gosa_aux_accounts))) {
                             msg_dialog::display (_ ("LDAP Error"),_ ("The LDAP search query with filter '.$_ldapfilter.' returned with an unknown error."), ERROR_DIALOG);
                         }
                     }
@@ -1468,7 +1489,6 @@ class importaccounts extends plugin{
         /* this will probably scale very very badly... Improvement needed. Suggestions? */
         foreach ($this->csvinfo['data_preldap'] as $key => $row)
         {
-
             if(strpos($row['main_account']['_actions'][0],'ignore')!==FALSE)
             {
                 continue;
@@ -2111,6 +2131,7 @@ class importaccounts extends plugin{
                     $_user_properties_extras["alias"] = $user_data['alias'][0];
                     if (in_array($uid_at_domain, $_user_properties_extras["alias"]))
                     {
+                        // FIXME: $key isn't set anywhere?
                         unset($_user_properties_extras["alias"][$key]);
                         $_user_properties_extras["alias"] = array_values($_user_properties_extras["alias"]);
                     }
@@ -2126,7 +2147,6 @@ class importaccounts extends plugin{
             $this->_ldap->cat($user_data['_base'][0]);
             if(!$this->_ldap->fetch())
             {
-
                 /* change UI "dir" in LDAP to the place where we want to create sub-OUs... */
                 $_ui= get_userinfo();
                 $old_ui_dn= $_ui->dn;

--- a/addons/schoolmanager/class_importstudentsandparents.inc
+++ b/addons/schoolmanager/class_importstudentsandparents.inc
@@ -213,7 +213,43 @@ class importstudentsandparents extends importaccounts {
                 $parent2['_actions']=array('none');
                 $parent2['_group_actions']= array('none');
 
-                /* groups for this account */
+                // If both parents email addresses are the same, handle parents as ONE gosa-account.
+                if ((isset($row_sorted['parent1_mail']) and $row_sorted['parent1_mail']) and
+                    (isset($row_sorted['parent2_mail']) and $row_sorted['parent2_mail']) and
+                    (isset($row_sorted['parent1_sn']) and ($row_sorted['parent1_sn']!=="")) and
+                    (isset($row_sorted['parent2_sn']) and ($row_sorted['parent2_sn']!=="")) and
+                    (isset($row_sorted['parent1_givenName']) and ($row_sorted['parent1_givenName']!=="")) and
+                    (isset($row_sorted['parent2_givenName']) and ($row_sorted['parent2_givenName']!=="")))
+                {
+                    if (strtolower(trim($row_sorted['parent1_mail'])) === strtolower(trim($row_sorted['parent2_mail'])))
+                    {
+                        // Do not import second parent account.
+                        //$parent2['mail']         = array();
+                        $parent2['_status']      = array('same-mail-as-parent1');
+                        $parent2['_actions']     = array('ignore');
+
+                        // givenName: Jon & Jane
+                        // second name: Doe & Smith  OR (if both have same the name):
+                        // second name: Doe
+                        if (strtolower(trim($row_sorted['parent1_sn'])) === strtolower(trim($row_sorted['parent2_sn'])))
+                        {
+                            $parent_surname = trim($row_sorted['parent1_sn']);
+                        } else {
+                            $parent_surname = trim($row_sorted['parent1_sn']) . " & " . trim($row_sorted['parent2_sn']);
+                        }
+
+                        // Always indicate that this account represents two real people (if both have the same name, it would be something like Jon & Jon)
+                        $parent_givenName = trim($row_sorted['parent1_givenName']) . " & " . trim($row_sorted['parent2_givenName']);
+
+                        // *Parent1* represents two real people now. (since both have the same email address.)
+                        $parent1['sn'] = array($parent_surname);
+                        $parent1['givenName'] = array($parent_givenName);
+                    }
+                }
+
+                /*
+                 * Groups for this account:
+                 */
 
                 /* class group */
                 $class_group= array ();

--- a/addons/schoolmanager/class_importstudentsandparents.inc
+++ b/addons/schoolmanager/class_importstudentsandparents.inc
@@ -224,9 +224,8 @@ class importstudentsandparents extends importaccounts {
                     if (strtolower(trim($row_sorted['parent1_mail'])) === strtolower(trim($row_sorted['parent2_mail'])))
                     {
                         // Do not import second parent account.
-                        //$parent2['mail']         = array();
                         $parent2['_status']      = array('same-mail-as-parent1');
-                        $parent2['_actions']     = array('ignore');
+                        $parent2['_actions']     = array('ignore,combined-with-parent1');
 
                         // givenName: Jon & Jane
                         // second name: Doe & Smith  OR (if both have same the name):


### PR DESCRIPTION
Imagine both parents give us the same email address.

We have a few scenarios:

### Scenario "same mail" "same lastname"
parent1:
  - Jon Doe
  - my.mail@example.com
 
parent2:
  - Jane Doe
  - my.mail@example.com

**Should results in:**
parent1:
  - givenName: Jon & Jane
  - sn: Doe
  - mail: my.mail@example.com
 
### Scenario "same mail" "same given name" and "same lastname"
parent1:
  - Jon Doe
  - my.mail@example.com
 
parent2:
  - Jon Doe
  - my.mail@example.com

**Should results in:**
parent1:
  - givenName: Jon & Jon
  - sn: Doe
  - mail: my.mail@example.com

### Scenario "only same email"
parent1:
  - Jon Dough
  - my.mail@example.com
 
parent2:
  - Jane Doe
  - my.mail@example.com

**Should results in:**
parent1:
  - givenName: Jon & Jane
  - sn: Dough & Doe (respect the order)
  - mail: my.mail@example.com
  
  
### Scenario "not the same mail" "same lastname"
parent1:
  - Jon Doe
  - jon.doe@example.com
 
parent2:
  - Jane Doe
  - jane.doe@example.com

**Should results in:**
parent1:
  - givenName: Jon
  - sn: Doe
  - mail: jon.doe@example.com

parent2:
  - givenName: Jane
  - sn: Doe
  - mail: jane.doe@example.com