### PR TITLE
Improvement: Load defaults from config using GOsa²'s properties system.

### DIFF
--- a/addons/schoolmanager/class_importaccounts.inc
+++ b/addons/schoolmanager/class_importaccounts.inc
@@ -2057,8 +2057,6 @@ class importaccounts extends plugin
         } else {
             $usertab->save();
 
-            echo "success<br>";
-
             // Present a status update in GOsa²'s logging system (/var/log/syslog mostly)
             if ($this->utils->strcontains($user_data['_actions'][0], 'create')) {
                 new log("create", "users/user", $usertab->dn, array(), "New user (" . $usertab->sn . ", " . $usertab->givenName . ") created via SchoolManager add-on.");

--- a/addons/schoolmanager/class_importaccounts.inc
+++ b/addons/schoolmanager/class_importaccounts.inc
@@ -139,7 +139,7 @@ class importaccounts extends plugin
                 break;
             default:
                 // Default CSV delimiter.
-                $delimiter_char = $this->utils->getConfigValue("csv_column_delimiter");
+                $delimiter_char = $this->utils->getConfigStrValue("csv_column_delimiter");
                 break;
         }
 

--- a/addons/schoolmanager/class_importaccounts.inc
+++ b/addons/schoolmanager/class_importaccounts.inc
@@ -179,17 +179,11 @@ class importaccounts extends plugin
         $this->csvinfo['templates']['DNs'][] = "";
 
         // Set the default mail domain for users, groups and for the school here (they might differ)…
-        $this->csvinfo['domain_school'] = "intern";
-        $this->csvinfo['domain_users']  = "intern";
-        $this->csvinfo['domain_groups'] = "intern";
+        $this->csvinfo['domain_school'] = $this->utils->getConfigStrValue("domain_school");
+        $this->csvinfo['domain_users']  = $this->utils->getConfigStrValue("domain_users");
+        $this->csvinfo['domain_groups'] = $this->utils->getConfigStrValue("domain_groups");
 
-        $_base_search = $this->_ldap->search("(objectClass=dcObject)", array("o"));
-        $_base_obj = $this->_ldap->fetch($_base_search, $this->config->current['BASE']);
-
-        // FIXME: Do a is_valid_domain_name check here…
-        if (isset($_base_obj['o']) and isset($_base_obj['o'][0])) {
-            $this->csvinfo['domain_school'] = trim($_base_obj['o'][0]);
-        }
+        // TODO: FIXME: Check the domains above for validity!
 
         // Search for GOsa² user templates in LDAP-tree
         $_ldapsearch = $this->_ldap->search("(objectClass=gosaUserTemplate)", array("*"));
@@ -289,17 +283,17 @@ class importaccounts extends plugin
 
         $smarty->assign("ous_available", $this->csvinfo['ou_tree']['formfields']);
 
-        // Set import configuration defaults
-        $this->csvinfo['ou_groups'] = $default_ou_for_groups;
-        $this->csvinfo['accounts_in_class_ou']              = TRUE;
-        $this->csvinfo['aliases_in_schooldomain']           = TRUE;
-        $this->csvinfo['try_mail_as_uid']                   = TRUE;
-        $this->csvinfo['sel_ldap_match_attr_studentid']     = FALSE;
-        $this->csvinfo['sel_ldap_match_attr_givenname']     = TRUE;
-        $this->csvinfo['sel_ldap_match_attr_snname']        = TRUE;
-        $this->csvinfo['sel_ldap_match_attr_birthday']      = TRUE;
-        $this->csvinfo['sel_ldap_match_attr_gender']        = TRUE;
-        $this->csvinfo['add_course_members_to_class_group'] = TRUE;
+        // Set import configuration defaults for next phase.
+        $this->csvinfo['ou_groups']                         = $default_ou_for_groups;
+        $this->csvinfo['accounts_in_class_ou']              = $this->utils->getConfigBoolValue("accounts_in_class_ou");;
+        $this->csvinfo['add_course_members_to_class_group'] = $this->utils->getConfigBoolValue("add_course_members_to_class_group");;
+        $this->csvinfo['aliases_in_schooldomain']           = $this->utils->getConfigBoolValue("aliases_in_schooldomain");;
+        $this->csvinfo['try_mail_as_uid']                   = $this->utils->getConfigBoolValue("try_mail_as_uid");;
+        $this->csvinfo['sel_ldap_match_attr_studentid'] = $this->utils->getConfigBoolValue("ldap_match_attr_studentid");
+        $this->csvinfo['sel_ldap_match_attr_givenname'] = $this->utils->getConfigBoolValue("ldap_match_attr_givenname");
+        $this->csvinfo['sel_ldap_match_attr_snname']    = $this->utils->getConfigBoolValue("ldap_match_attr_snname");
+        $this->csvinfo['sel_ldap_match_attr_birthday']  = $this->utils->getConfigBoolValue("ldap_match_attr_birthday");
+        $this->csvinfo['sel_ldap_match_attr_gender']    = $this->utils->getConfigBoolValue("ldap_match_attr_gender");
 
         // Provide pre-set values for account template forms
         $smarty->assign("preset_template_" . $this->import_account_type,          $this->csvinfo['template_main']);
@@ -311,12 +305,12 @@ class importaccounts extends plugin
         $smarty->assign("preset_accounts_in_class_ou",                            $this->csvinfo['accounts_in_class_ou']);
         $smarty->assign("preset_aliases_in_schooldomain",                         $this->csvinfo['aliases_in_schooldomain']);
         $smarty->assign("preset_try_mail_as_uid",                                 $this->csvinfo['try_mail_as_uid']);
+        $smarty->assign("preset_add_course_members_to_class_group",               $this->csvinfo['add_course_members_to_class_group']);
         $smarty->assign("preset_sel_ldap_match_attr_studentid",                   $this->csvinfo['sel_ldap_match_attr_studentid']);
         $smarty->assign("preset_sel_ldap_match_attr_givenname",                   $this->csvinfo['sel_ldap_match_attr_givenname']);
         $smarty->assign("preset_sel_ldap_match_attr_snname",                      $this->csvinfo['sel_ldap_match_attr_snname']);
         $smarty->assign("preset_sel_ldap_match_attr_birthday",                    $this->csvinfo['sel_ldap_match_attr_birthday']);
         $smarty->assign("preset_sel_ldap_match_attr_gender",                      $this->csvinfo['sel_ldap_match_attr_gender']);
-        $smarty->assign("preset_add_course_members_to_class_group",               $this->csvinfo['add_course_members_to_class_group']);
     }
 
 

--- a/addons/schoolmanager/class_importaccounts.inc
+++ b/addons/schoolmanager/class_importaccounts.inc
@@ -795,15 +795,47 @@ class importaccounts extends plugin
             $this->csvinfo = array();
         }
 
-        // TODO: Replace current delimiter system and replace it with properties.
-        $smarty->assign('available_delimiters', array(
-            0 => '"," - ' . _("comma separated values"),
-            1 => '";" - ' . _("semicolon separated values"),
-            2 => '<-> - ' . _("tabstop separated values"),
-            3 => '" " - ' . _("blank separated values")
-        ));
+        // Get setting's default.
+        $delim_char = $this->utils->getConfigStrValue("csv_column_delimiter");
 
-        $smarty->assign('preset_delimiter_id', 0);
+        switch ($delim_char) {
+            case ",":
+                $delimiter_index = 0;
+                break;
+            case ";":
+                $delimiter_index = 1;
+                break;
+            case "\t":
+                $delimiter_index = 2;
+                break;
+            case " ":
+                $delimiter_index = 3;
+                break;
+            default:
+                // Custom character…
+                $delimiter_index = 4;
+                break;
+        }
+
+        $smarty->assign('preset_delimiter_id', $delimiter_index);
+        $available_delims = array(
+            0 => '","'  . " - " . _("comma separated values"),
+            1 => '";"'  . " - " . _("semicolon separated values"),
+            2 => '"\t"' . " - " . _("tabstop separated values"),
+            3 => '" "'  . " - " . _("blank separated values"),
+        );
+
+        // Add custom character radio button only if it should appear.
+        if ($delimiter_index === 4) {
+            $available_delims[4] = '"' . $delim_char . '" - ' . _("values seperated by custom character");
+        }
+
+        $smarty->assign('available_delimiters', $available_delims);
+
+        // Get setting's default.
+        $value = $this->utils->getConfigBoolValue("ignore_first_row_of_csv_file");
+        $smarty->assign('preset_csv_with_column_headers', $value);
+
 
         $this->csvinfo['attrs'] = $this->getAttributes();
         $this->csvinfo['attrs'][] = "---";

--- a/addons/schoolmanager/class_importaccounts.inc
+++ b/addons/schoolmanager/class_importaccounts.inc
@@ -299,7 +299,7 @@ class importaccounts extends plugin
         $smarty->assign("preset_template_" . $this->import_account_type,          $this->csvinfo['template_main']);
         $smarty->assign("preset_template_" . $this->import_account_type . "_aux", $this->csvinfo['template_aux']);
         $smarty->assign("preset_ou_groups",                                       $this->csvinfo['ou_groups']);
-        $smarty->assign("domain_school",                                          $this->csvinfo['domain_school']);
+        $smarty->assign("preset_domain_school",                                   $this->csvinfo['domain_school']);
         $smarty->assign("preset_domain_users",                                    $this->csvinfo['domain_users']);
         $smarty->assign("preset_domain_groups",                                   $this->csvinfo['domain_groups']);
         $smarty->assign("preset_accounts_in_class_ou",                            $this->csvinfo['accounts_in_class_ou']);

--- a/addons/schoolmanager/class_schoolmgr.inc
+++ b/addons/schoolmanager/class_schoolmgr.inc
@@ -166,6 +166,27 @@ class schoolmgr extends plugin
             ),
             // Gets loaded as defaults for phase 2…
             array(
+                "name"        => "aliases_in_schooldomain",
+                "type"        => "bool",
+                "check"       => "gosaProperty::isBool",
+                "group"       => "schoolmgr",
+                "default"     => "true",
+                "migrate"     => "",
+                "mandatory"   => TRUE,
+                "description" => _("Should aliases be created for teachers using the school domain? " .
+                                   "For example: <uid>@<domain_school>"),
+            ),
+            array(
+                "name"        => "add_course_members_to_class_group",
+                "type"        => "bool",
+                "check"       => "gosaProperty::isBool",
+                "group"       => "schoolmgr",
+                "default"     => "true",
+                "migrate"     => "",
+                "mandatory"   => TRUE,
+                "description" => _("Should teachers be included as class members for courses they teach in a class?"),
+            ),
+            array(
                 "name"        => "accounts_in_class_ou",
                 "type"        => "bool",
                 "check"       => "gosaProperty::isBool",
@@ -178,14 +199,34 @@ class schoolmgr extends plugin
                                    "corresponding class OU?"),
             ),
             array(
-                "name"        => "domain_for_new_groups",
+                "name"        => "domain_groups",
                 "type"        => "string",
                 "check"       => "gosaProperty::isString",
                 "group"       => "schoolmgr",
-                "default"     => "@intern",
+                "default"     => "intern", // Without leading '@'
                 "migrate"     => "",
                 "mandatory"   => TRUE,
-                "description" => _("In what mail domain should new groups be?"),
+                "description" => _("The groups domain. Example: 'lists.john-doe-school.edu'"),
+            ),
+            array(
+                "name"        => "domain_users",
+                "type"        => "string",
+                "check"       => "gosaProperty::isString",
+                "group"       => "schoolmgr",
+                "default"     => "intern", // Without leading '@'
+                "migrate"     => "",
+                "mandatory"   => TRUE,
+                "description" => _("The users (pupil) domain. Example: 'pupils.john-doe-school.edu'"),
+            ),
+            array(
+                "name"        => "domain_school",
+                "type"        => "string",
+                "check"       => "gosaProperty::isString",
+                "group"       => "schoolmgr",
+                "default"     => "intern", // Without leading '@'
+                "migrate"     => "",
+                "mandatory"   => TRUE,
+                "description" => _("The school domain. Example: 'john-doe-school.edu'"),
             ),
             array(
                 "name"        => "try_mail_as_uid",

--- a/addons/schoolmanager/class_schoolmgr.inc
+++ b/addons/schoolmanager/class_schoolmgr.inc
@@ -83,9 +83,67 @@ class schoolmgr extends plugin
         );
     }
 
-
     static function getProperties() {
-        return array(
+        $matching_attr_arr = array(
+            array(
+                "name"        => "ldap_match_attr_studentid",
+                "type"        => "bool",
+                "check"       => "gosaProperty::isBool",
+                "group"       => "schoolmgr",
+                "default"     => "false",
+                "migrate"     => "",
+                "mandatory"   => TRUE,
+                "description" => _("Should this attribute be used to identify users " .
+                                   "from the CSV file as existing users in the LDAP-tree?"),
+            ),
+            array(
+                "name"        => "ldap_match_attr_givenname",
+                "type"        => "bool",
+                "check"       => "gosaProperty::isBool",
+                "group"       => "schoolmgr",
+                "default"     => "true",
+                "migrate"     => "",
+                "mandatory"   => TRUE,
+                "description" => _("Should this attribute be used to identify users " .
+                                   "from the CSV file as existing users in the LDAP-tree?"),
+            ),
+            array(
+                "name"        => "ldap_match_attr_snname",
+                "type"        => "bool",
+                "check"       => "gosaProperty::isBool",
+                "group"       => "schoolmgr",
+                "default"     => "true",
+                "migrate"     => "",
+                "mandatory"   => TRUE,
+                "description" => _("Should this attribute be used to identify users " .
+                                   "from the CSV file as existing users in the LDAP-tree?"),
+            ),
+            array(
+                "name"        => "ldap_match_attr_birthday",
+                "type"        => "bool",
+                "check"       => "gosaProperty::isBool",
+                "group"       => "schoolmgr",
+                "default"     => "false",
+                "migrate"     => "",
+                "mandatory"   => TRUE,
+                "description" => _("Should this attribute be used to identify users " .
+                                   "from the CSV file as existing users in the LDAP-tree?"),
+            ),
+            array(
+                "name"        => "ldap_match_attr_gender",
+                "type"        => "bool",
+                "check"       => "gosaProperty::isBool",
+                "group"       => "schoolmgr",
+                "default"     => "true",
+                "migrate"     => "",
+                "mandatory"   => TRUE,
+                "description" => _("Should this attribute be used to identify users " .
+                                   "from the CSV file as existing users in the LDAP-tree?"),
+            ),
+        );
+
+        $ret_arr = array(
+            // Gets loaded as defaults for phase 1…
             array(
                 "name"        => "csv_column_delimiter",
                 "type"        => "string",
@@ -96,6 +154,17 @@ class schoolmgr extends plugin
                 "mandatory"   => TRUE,
                 "description" => _("The default delimiter for CSV file columns."),
             ),
+            array(
+                "name"        => "ignore_first_row_of_csv_file",
+                "type"        => "bool",
+                "check"       => "gosaProperty::isBool",
+                "group"       => "schoolmgr",
+                "default"     => "true",
+                "migrate"     => "",
+                "mandatory"   => TRUE,
+                "description" => _("The first row of the CSV file contains column heads."),
+            ),
+            // Gets loaded as defaults for phase 2…
             array(
                 "name"        => "accounts_in_class_ou",
                 "type"        => "bool",
@@ -109,6 +178,16 @@ class schoolmgr extends plugin
                                    "corresponding class OU?"),
             ),
             array(
+                "name"        => "domain_for_new_groups",
+                "type"        => "string",
+                "check"       => "gosaProperty::isString",
+                "group"       => "schoolmgr",
+                "default"     => "@intern",
+                "migrate"     => "",
+                "mandatory"   => TRUE,
+                "description" => _("In what mail domain should new groups be?"),
+            ),
+            array(
                 "name"        => "try_mail_as_uid",
                 "type"        => "bool",
                 "check"       => "gosaProperty::isBool",
@@ -120,16 +199,6 @@ class schoolmgr extends plugin
                                    "column, use the mail address as user ID instead?"),
             ),
             array(
-                "name"        => "ignore_first_row_of_csv_file",
-                "type"        => "bool",
-                "check"       => "gosaProperty::isBool",
-                "group"       => "schoolmgr",
-                "default"     => "true",
-                "migrate"     => "",
-                "mandatory"   => TRUE,
-                "description" => _("The first row of the CSV file contains column heads."),
-            ),
-            array(
                 "name"        => "ou_for_new_groups",
                 "type"        => "dn",
                 "check"       => "gosaProperty::isDn",
@@ -138,16 +207,6 @@ class schoolmgr extends plugin
                 "migrate"     => "",
                 "mandatory"   => TRUE,
                 "description" => _("The OU for new groups."),
-            ),
-            array(
-                "name"        => "domain_for_new_groups",
-                "type"        => "string",
-                "check"       => "gosaProperty::isString",
-                "group"       => "schoolmgr",
-                "default"     => "@intern",
-                "migrate"     => "",
-                "mandatory"   => TRUE,
-                "description" => _("In what mail domain should new groups be?"),
             ),
             array(
                 "name"        => "template_for_new_students-importstudentsonly",
@@ -190,6 +249,8 @@ class schoolmgr extends plugin
                 "description" => _("Import teachers: Select a template for teacher accounts."),
             ),
         );
+
+        return array_merge($ret_arr, $matching_attr_arr);
     }
 }
 

--- a/addons/schoolmanager/class_utils.inc
+++ b/addons/schoolmanager/class_utils.inc
@@ -52,7 +52,8 @@ class schoolmgr_utils
     }
 
 
-    function getConfigValue(string $key): string {
+    function getConfigStrValue(string $key): string
+    {
         // Define our main class
         $class = "schoolmgr";
 
@@ -61,7 +62,31 @@ class schoolmgr_utils
         $ret = $this->config->get_cfg_value($class, $key);
 
         // Debug property to js console (if debugging is enabled!).
-        $debug_str = "Got property(" . $class . "): '" . str_pad($key . "':", 60) . "'" . $ret . "'";
+        $debug_str = "Got string property '" . str_pad($key . "':", 58) . "'" . $ret . "'";
+        $this->debug_to_console($debug_str);
+
+        return $ret;
+    }
+
+
+    function getConfigBoolValue(string $key): bool
+    {
+        // Get config value, but pause debugging output.
+        $debug_mode_then = $this->DEBUG_MODE;
+        $this->DEBUG_MODE = FALSE;
+        $conf_value = strtolower($this->getConfigStrValue($key));
+        $this->DEBUG_MODE = $debug_mode_then;
+
+        $ret = FALSE;
+
+        // Only return TRUE if value is literally "true"…
+        if ($conf_value === "true") {
+            $ret = TRUE;
+        }
+
+        // Debug property to js console (if debugging is enabled!).
+        $ret_str = $ret ? "✅" : "❌";
+        $debug_str = "Got bool property '" . str_pad($key . "':", 60) . "'" . $ret_str . "'";
         $this->debug_to_console($debug_str);
 
         return $ret;

--- a/addons/schoolmanager/class_utils.inc
+++ b/addons/schoolmanager/class_utils.inc
@@ -36,12 +36,14 @@ class schoolmgr_utils
 
     // str_contains is not available for PHP 7.
     // So we write our own function wrapper.
-    function strcontains(string $haystack, string $needle): bool {
+    function strcontains(string $haystack, string $needle): bool
+    {
         return strpos($haystack, $needle) !== FALSE;
     }
 
 
-    function debug_to_console($data) {
+    function debug_to_console($data)
+    {
         // Don't print anything to js console, if DEBUG_MODE isn't 'true'.
         if ($this->DEBUG_MODE !== true) return;
 

--- a/addons/schoolmanager/content_importaccounts.tpl
+++ b/addons/schoolmanager/content_importaccounts.tpl
@@ -89,7 +89,11 @@
 	<tr>
 		<td style=vertical-align: middle;">
 			<LABEL for="csv_with_column_headers">{t}First line in CSV file contains column headers (so ignore that first line):{/t}</LABEL>
-			<input type="checkbox" id="csv_with_column_headers" name="csv_with_column_headers" checked>
+			{if $preset_csv_with_column_headers}
+				<input type="checkbox" id="csv_with_column_headers" name="csv_with_column_headers" checked>
+			{else}
+				<input type="checkbox" id="csv_with_column_headers" name="csv_with_column_headers">
+			{/if}
 		</td>
 	</tr>
 	<tr>

--- a/addons/schoolmanager/content_importaccounts.tpl
+++ b/addons/schoolmanager/content_importaccounts.tpl
@@ -237,11 +237,11 @@
 		</td>
 	</tr>
 
-{if $domain_school}
+{if $preset_domain_school}
 	<tr>
 		<td style="width: 1em;">&nbsp;</td>
 		<td style="vertical-align: middle;">
-			<LABEL for="aliases_in_schooldomain">{t}Teachers shall have mail aliases in the school's mail domain ({$domain_school}):{/t}</LABEL>
+			<LABEL for="aliases_in_schooldomain">{t}Teachers shall have mail aliases in the school's mail domain ({$preset_domain_school}):{/t}</LABEL>
 		</td>
 		<td style="vertical-align: middle;">
 {if $preset_aliases_in_schooldomain}


### PR DESCRIPTION
Defaults (at least for the first two phases) should be configurable using GOsa² property editor or by injecting entries into the LDAP-tree.

Example LDAP entry:
```
669 cn=schoolmgr,ou=gosa,ou=configs,ou=systems,dc=skole,dc=skolelinux,dc=no
cn: schoolmgr
objectClass: top
objectClass: gosaConfig
gosaSetting: ldap_match_attr_studentid:false
gosaSetting: ldap_match_attr_givenname:true
gosaSetting: ldap_match_attr_snname:true
gosaSetting: ldap_match_attr_birthday:false
gosaSetting: domain_groups:domain_groups.test
gosaSetting: domain_users:domain_users.test
gosaSetting: domain_school:domain_school.test
```

### DEPENDS ON #32 