### PR TITLE
Fix default delim char recognition for tab-char.

### DIFF
--- a/addons/schoolmanager/class_importaccounts.inc
+++ b/addons/schoolmanager/class_importaccounts.inc
@@ -806,7 +806,7 @@ class importaccounts extends plugin
             case ";":
                 $delimiter_index = 1;
                 break;
-            case "\t":
+            case "\\t": // Not the actual tab char but literally '\t'
                 $delimiter_index = 2;
                 break;
             case " ":


### PR DESCRIPTION
It's not user friendly to expect an actual tab character, but instead expect literally '\t'.