### PR TITLE
Fix: Quick-Import: Always get settings from user (instead of config) for 1st phase.

### DIFF
--- a/addons/schoolmanager/class_importaccounts.inc
+++ b/addons/schoolmanager/class_importaccounts.inc
@@ -113,18 +113,9 @@ class importaccounts extends plugin
      */
     function execute_phase1($smarty, $quick_import = false)
     {
-        /* Load defaults, if we run in quick import mode */
-        if ($quick_import === false) {
-            $_delim_id                = $_POST['delimiter_id'];
-            $_csv_with_column_headers = $_POST['csv_with_column_headers'];
-        } else {
-            $_delim_id                = -1; // Will load default char later.
-
-            $_csv_with_column_headers = $this->utils->getConfigBoolValue("ignore_first_row_of_csv_file");
-            if ($_csv_with_column_headers === false) {
-                unset($_csv_with_column_headers);
-            }
-        }
+        // This is the first phase, so no need to worry about quick-import.
+        $_delim_id                = $_POST['delimiter_id'];
+        $_csv_with_column_headers = $_POST['csv_with_column_headers'];
 
         $ret_array = $this->utils->checkUploadedFile();
 


### PR DESCRIPTION
When doing a Quick-Import, user settings (in the first phase) would be just ignored.

## Depends on #48 