### PR TITLE
Add schoolmgr_utils type to $this->$utils everywhere.

### DIFF
--- a/addons/schoolmanager/class_import.inc
+++ b/addons/schoolmanager/class_import.inc
@@ -57,6 +57,9 @@ class import extends plugin
     // Collection container for failure messages
     var $failure_messages = array();
 
+    // Schoolmgr Utility class instance
+    var schoolmgr_utils $utils;
+
     // import class constructor
     function __construct(&$config, $dn = null)
     {

--- a/addons/schoolmanager/class_schoolmanagerintro.inc
+++ b/addons/schoolmanager/class_schoolmanagerintro.inc
@@ -40,6 +40,8 @@ class schoolmanagerintro extends plugin
     /* SchoolManager specific properties */
     var $ldapinfo = [];
 
+    // Schoolmgr Utility class instance
+    var schoolmgr_utils $utils;
 
     function __construct(&$config, $dn = null)
     {

--- a/addons/schoolmanager/class_smflushgroupmembers.inc
+++ b/addons/schoolmanager/class_smflushgroupmembers.inc
@@ -28,6 +28,9 @@ class smflushgroupmembers
     /** Template URI (.tpl file) */
     const TEMPLATE_URI = "smflushgroupmembers/content_smflushgroupmembers.tpl";
 
+    // Schoolmgr Utility class instance
+    var schoolmgr_utils $utils;
+
     function __construct(&$config, schoolmgr_utils &$utils)
     {
         $this->config = $config;


### PR DESCRIPTION
Fixing this lets us traverse code better with modern IDEs, since they now understand what the type of the var is.